### PR TITLE
Update LocalConfigInfoProcessor.php

### DIFF
--- a/src/alibaba/nacos/NacosClient.php
+++ b/src/alibaba/nacos/NacosClient.php
@@ -60,7 +60,8 @@ class NacosClient implements NacosClientInterface
         $getConfigRequest = new GetConfigRequest();
         $getConfigRequest->setDataId($dataId);
         $getConfigRequest->setGroup($group);
-
+        $getConfigRequest->setTenant($tenant);
+        
         try {
             $response = $getConfigRequest->doRequest();
             $config = $response->getBody()->getContents();

--- a/src/alibaba/nacos/failover/LocalConfigInfoProcessor.php
+++ b/src/alibaba/nacos/failover/LocalConfigInfoProcessor.php
@@ -63,7 +63,7 @@ class LocalConfigInfoProcessor extends Processor
     {
         $snapshotFile = self::getSnapshotFile($envName, $dataId, $group, $tenant);
         if (!$config) {
-            unlink($snapshotFile);
+            @unlink($snapshotFile);
         } else {
             $file = new SplFileInfo($snapshotFile);
             if (!is_dir($file->getPath())) {


### PR DESCRIPTION
配置文件手动删除时，再次更新配置，此时会报错 No such file or directory

增加 @ 符号，屏蔽错误。